### PR TITLE
Fixed line number test case and off-by-one error in DrJava

### DIFF
--- a/drjava/src/edu/rice/cs/drjava/model/GlobalModelCompileErrorsTest.java
+++ b/drjava/src/edu/rice/cs/drjava/model/GlobalModelCompileErrorsTest.java
@@ -331,7 +331,7 @@ public final class GlobalModelCompileErrorsTest extends GlobalModelTestCase {
     Position p1 = cme.getPosition(ce1);
     Position p2 = cme.getPosition(ce2);
     assertTrue("location of first error should be between 20 and 29 inclusive (line 2), but was " + p1.getOffset(),
-               p1.getOffset() <= 20 && p1.getOffset() <= 29);
+               p1.getOffset() >= 20 && p1.getOffset() <= 29);
     assertTrue("location of error should be after 34 (line 3 or 4)", p2.getOffset() >= 34);
     
     debug.logEnd();

--- a/drjava/src/edu/rice/cs/drjava/model/compiler/JavaxToolsCompiler.java
+++ b/drjava/src/edu/rice/cs/drjava/model/compiler/JavaxToolsCompiler.java
@@ -91,8 +91,8 @@ public class JavaxToolsCompiler implements CompilerInterface {
         List<DJError> errors = new ArrayList<>();
         for (Diagnostic<? extends JavaFileObject> diagnostic : diagnostics.getDiagnostics()) {
             DJError error = new DJError(new File(diagnostic.getSource().toUri()),
-                    (int) diagnostic.getLineNumber(),
-                    (int) diagnostic.getColumnNumber(),
+                    (int) diagnostic.getLineNumber() - 1, // DJError adds 1 to this number.
+                    (int) diagnostic.getColumnNumber() - 1, // Fixes the cursor position offset.
                     diagnostic.getMessage(null),
                     diagnostic.getKind() == Diagnostic.Kind.ERROR);
             errors.add(error);


### PR DESCRIPTION
The test case that was failing was checking for` (p1.getOffset() <= 20 && p1.getOffset() <= 29) instead of (p1.getOffset() >= 20 && p1.getOffset() <= 29)`. The description in the String is valid; the syntax error is in the line that starts at position 20. The compiler now has the correct line and column number that the DrJava UI uses to display where the error occurred and to position the cursor at when clicking on the error.